### PR TITLE
Update ethereumjs-util dependency from v6.1.0 to v7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "async": "^2.1.2",
     "buffer-xor": "^2.0.1",
-    "ethereumjs-util": "^6.1.0",
+    "ethereumjs-util": "^7.0.2",
     "miller-rabin": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Follow-up on #19, taking the occasion since `ethereumjs-util` upgrade to `v7.0.2` is in progress on several of the EthereumJS libraries, see e.g. https://github.com/ethereumjs/ethereumjs-vm/pull/748